### PR TITLE
Hide Retweet hides entire original tweet on single-status pages

### DIFF
--- a/troynts_twitter_script.user.js
+++ b/troynts_twitter_script.user.js
@@ -431,7 +431,7 @@ tnt_twitter = {
     }
     
     if( tnt_twitter.can('hide_retweets') ) {
-      css += '.status.share { display:none !important; }';
+      css += 'li.status.share { display:none !important; }';
     }
 	
     /* media embed */


### PR DESCRIPTION
With "Hide Retweets" turned on, view http://twitter.com/scribblybot/statuses/23167202361. The entire tweet will be hidden because it's been retweeted and so has both the status and share classes.  This commit restricts the css selector to only <li>s that have those classes, so they are hidden from the profile page, but single-status pages that have been retweeted (and have both share and status classes) are not.

I did not bump the version number, since I imagine you won't send this as a stand-alone update.
